### PR TITLE
Add eslint-plugin-import

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@
 
 module.exports = {
   extends: 'google',
+  plugins: [
+    "eslint-plugin-import"
+  ],
   rules: {
     "max-len": ["error", 120],
     "require-jsdoc": "off"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-salemove",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "SaleMove's shareable ESLint config",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/salemove/eslint-config-salemove#readme",
   "dependencies": {
     "eslint": "^3.2.2",
-    "eslint-config-google": "^0.6.0"
+    "eslint-config-google": "^0.6.0",
+    "eslint-plugin-import": "^1.15.0"
   }
 }


### PR DESCRIPTION
This plugin intends to support linting of ES2015+ (ES6+) import/export
syntax, and prevent issues with misspelling of file paths and import
names. All the goodness that the ES2015+ static module syntax intends to
provide, marked up in your editor.